### PR TITLE
chore: simplify git log command

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-BASE_SHA=$(git rev-parse --verify "origin/${GITHUB_BASE_REF}^{commit}")
-HEAD_SHA=$(git rev-parse --verify "origin/${GITHUB_HEAD_REF}^{commit}")
-git log --pretty=%s "${BASE_SHA}..${HEAD_SHA}" | grep --quiet -E '^(amend|fixup|squash)!' && exit 1 || exit 0
+git log --pretty=%s --walk-reflogs | grep --quiet -E '^(amend|fixup|squash)!' && exit 1 || exit 0


### PR DESCRIPTION
Use --walk-reflog instead of figuring a bunch of stuff out like an animal.