### PR TITLE
fix: the whole action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,18 +2,8 @@ name: CI
 on: pull_request
 
 jobs:
-  shellcheck:
-    name: ShellCheck
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.1
-      - name: ShellCheck
-        run: |-
-          shellcheck ./action.sh
   dogfooding:
     name: Dogfooding
-    needs: shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/action.sh
+++ b/action.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euxo pipefail
-
-git log --pretty=%s --walk-reflogs | grep --quiet -E '^(amend|fixup|squash)!' && exit 1 || exit 0

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,9 @@ runs:
 
     - name: Check if there are 'amend!', 'fixup!', and 'squash!' commits
       run: |
-        ./action.sh
+        BASE_REF=$(git rev-parse --verify "origin/${GITHUB_BASE_REF}^{commit}")
+        HEAD_REF=$(git rev-parse --verify "origin/${GITHUB_HEAD_REF}^{commit}")
+        ! git log --pretty=%s "${BASE_REF}..${HEAD_REF}" | grep --quiet -E '^(amend|fixup|squash)!'
       shell: bash
 
 branding:


### PR DESCRIPTION
Composite actions can seemingly not contain extra script files, but this should work just as well. It is just lacking the ShellCheck, but that was not adding that much to begin with.