### PR TITLE
feat: add step summary for non-PR runs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,9 @@ runs:
     - name: Check if this is a pull request
       if: ${{ github.event_name != 'pull_request' }}
       run: |
-        echo 'This action can only be run on pull requests.'
+        echo '### Error' >> ${GITHUB_STEP_SUMMARY}
+        echo '' >> ${GITHUB_STEP_SUMMARY}
+        echo 'This action can only be run on pull requests.' >> ${GITHUB_STEP_SUMMARY}
         exit 1
       shell: bash
 


### PR DESCRIPTION
When the action is used in a non-PR context, it used to output an error in the action, but move this to the summary of the action