### PR TITLE
refactor: use input redirection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
       run: |
         BASE_REF=$(git rev-parse --verify "origin/${GITHUB_BASE_REF}^{commit}")
         HEAD_REF=$(git rev-parse --verify "origin/${GITHUB_HEAD_REF}^{commit}")
-        ! git log --pretty=%s "${BASE_REF}..${HEAD_REF}" | grep --quiet -E '^(amend|fixup|squash)!'
+        ! grep --quiet -E '^(amend|fixup|squash)!' <(git log --pretty=%s "${BASE_REF}..${HEAD_REF}")
       shell: bash
 
 branding:


### PR DESCRIPTION
Use input redirection instead of piping the output of git log to grep.