### PR TITLE
build: skip checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,5 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Eating our own dogfood
         uses: ./
+        with:
+          skip-checkout: true


### PR DESCRIPTION
Checkout is not necessary when the repo has already been checked out as is the case here.