### PR TITLE
feat: split out the action into action.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,14 @@ name: CI
 on: pull_request
 
 jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: ShellCheck
+        run: shellcheck action.sh
   dogfooding:
     name: Dogfooding
     runs-on: ubuntu-latest

--- a/action.sh
+++ b/action.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+BASE_REF=$(git rev-parse --verify "origin/${GITHUB_BASE_REF}^{commit}")
+HEAD_REF=$(git rev-parse --verify "origin/${GITHUB_HEAD_REF}^{commit}")
+! grep --quiet -E '^(amend|fixup|squash)!' <(git log --pretty=%s "${BASE_REF}..${HEAD_REF}")

--- a/action.yml
+++ b/action.yml
@@ -28,11 +28,14 @@ runs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
+    - name: Set GitHub Action path
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+      run: echo "${ACTION_PATH}" >> ${GITHUB_PATH}
+      shell: bash
+
     - name: Check if there are 'amend!', 'fixup!', and 'squash!' commits
-      run: |
-        BASE_REF=$(git rev-parse --verify "origin/${GITHUB_BASE_REF}^{commit}")
-        HEAD_REF=$(git rev-parse --verify "origin/${GITHUB_HEAD_REF}^{commit}")
-        ! grep --quiet -E '^(amend|fixup|squash)!' <(git log --pretty=%s "${BASE_REF}..${HEAD_REF}")
+      run: action.sh
       shell: bash
 
 branding:


### PR DESCRIPTION
Factor out the action into action.sh so it can be shellchecked. Use `github.action_path` this time so it works properly when used as an action.